### PR TITLE
Fix escaping in *** Punctuation.

### DIFF
--- a/1.0-specification.norg
+++ b/1.0-specification.norg
@@ -77,7 +77,7 @@ version: 1.0
 
 *** Punctuation
     A {** characters}[character] is considered *punctuation* if it is any of the following:
-    - A standard ASCII punctuation character: `|!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~|`
+    - A standard ASCII punctuation character: `|!"#$%&'()*+,-./:;<=>?@[\\]^_\`{|}~|`
     - Anything in the general Unicode categories `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po` or `Ps`.
 
 *** Escaping


### PR DESCRIPTION
I don't know if that's on purpose, but just in case it is not, I fixed escaping within the inline code block that describes punctuation.